### PR TITLE
Update error handling in DataAnalyzer

### DIFF
--- a/src/etl/jobs/csv/DataAnalyzer.java
+++ b/src/etl/jobs/csv/DataAnalyzer.java
@@ -119,7 +119,7 @@ public class DataAnalyzer extends Job {
                                         vals.add(rec[col].trim());
                                     }
                                     catch (ArrayIndexOutOfBoundsException e){
-                                        System.out.println("Array out of bounds on " + Arrays.toString(rec) + " for col " + col + ". Array size is " + rec.length );
+                                        throw new RuntimeException("Array out of bounds on " + Arrays.toString(rec) + " for col " + col + ". Array size is " + rec.length + ". The data must be fixed and reprocessed.");
                                     }
                                 });
                                 newMappings.add(analyzeData(m, vals));


### PR DESCRIPTION
Replace log with RuntimeException for array out-of-bounds errors. This ensures we fail to process a study if the data is in a bad state.

There are corresponding updates to the Data Analyzer Jenkins job. See the ALS-11668 ticket comments for the updated bash scripts.